### PR TITLE
Added BRP packages to be more compatible with "osc build"

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -11,6 +11,8 @@ RUN zypper --non-interactive dup --no-recommends && zypper --non-interactive in 
   autoconf \
   automake \
   boost-devel \
+  brp-check-suse \
+  brp-extract-appdata \
   build \
   ccache \
   doxygen \


### PR DESCRIPTION
This is similar to https://github.com/yast/docker-yast-ruby/pull/31, check it for more details.